### PR TITLE
fix(login): make the login work on localhost

### DIFF
--- a/src/Login.js
+++ b/src/Login.js
@@ -15,11 +15,15 @@ Login.propTypes = {
 };
 
 function onClick(cb) {
-  const authenticator = new Netlify({});
+  const authenticator = new Netlify({
+    // eslint-disable-next-line camelcase
+    site_id: 'maintainer-dashboard.netlify.com',
+  });
   authenticator.authenticate(
     { provider: 'github', scope: 'user' },
     (err, data) => {
-      if (err) cb(undefined);
+      // eslint-disable-next-line no-console
+      if (err) console.warn(err.err.message);
       else {
         window.localStorage.setItem('GH_TOKEN', data.token);
         cb(data.token);


### PR DESCRIPTION
I read the error message, and the code, and saw the `site_id` should've been the site.netlify.com, and now I can login to localhost without making a new token :fire: